### PR TITLE
Modified to expose Alea instead of returnExports.

### DIFF
--- a/alea.js
+++ b/alea.js
@@ -4,7 +4,7 @@
   } else if (typeof define === 'function' && define.amd) {
       define(factory);
   } else {
-      root.returnExports = factory();
+      root.Alea = factory();
   }
 }(this, function () {
 


### PR DESCRIPTION
When importing alea using jake+node instead of explicitly calling require in each file, it exposes the function as returnExports instead of Alea.

This makes it return Alea.
